### PR TITLE
Fix modal error header layout

### DIFF
--- a/src/app/pages/projects/project-forms/rule-definition/rule-error/rule-error-modal.component.html
+++ b/src/app/pages/projects/project-forms/rule-definition/rule-error/rule-error-modal.component.html
@@ -3,7 +3,7 @@
     <div class="dialog">
 
         <div class="dialog-header">
-            <h3 i18n="@@HYT_error">Error</h3>
+            <span i18n="@@HYT_error">Error</span>
             <span class="hyt-icon icon-hyt_cancelC" (click)="close()"></span>
         </div>
 

--- a/src/app/pages/projects/project-forms/rule-definition/rule-error/rule-error-modal.component.scss
+++ b/src/app/pages/projects/project-forms/rule-definition/rule-error/rule-error-modal.component.scss
@@ -1,5 +1,5 @@
 #container-option-modal {
-  
+
   .dialog {
     overflow: hidden;
     background-color: #2258a5;
@@ -18,13 +18,19 @@
       h3 {
         margin: 0px;
         text-transform: uppercase;
-      } 
+      }
 
       span {
 
         &.icon-hyt_cancelC {
 
-          color: #ffffff;
+          position: absolute;
+          top: 50%;
+          right: 10px;
+          font-size: 1.3em;
+          transform: translateY(-50%);
+          cursor: pointer;
+          color: #fff;
 
           &:hover {
 
@@ -44,7 +50,7 @@
     }
 
   }
-  
+
 }
 
 


### PR DESCRIPTION
I fixed modal error layout.
Change from h3 to span for modal title and add correct CSS entry line for header modal class.