### PR TITLE
Fix range selected on online linechart

### DIFF
--- a/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
+++ b/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
@@ -287,14 +287,14 @@ export class LineChartComponent
   }
 
   isLoadingData(){
-    if(this.dataService['rangeSelectionDataAlreadyLoaded'].value){
+    if(this.dataService['rangeSelectionDataAlreadyLoaded']?.value){
       return false;
     }
     return this.loadingOfflineData;
   }
 
   noRangeSelected(){
-    return !this.dataService['isRangeSelected'];
+    return this.serviceType === ServiceType.OFFLINE && !this.dataService['isRangeSelected'];
   }
 
   updateDataRequest() {


### PR DESCRIPTION
In the online version, don't show the overlay if a range is not selected