### PR TITLE
Fix filter device to dashboard device

### DIFF
--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/bodymap-settings/bodymap-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/bodymap-settings/bodymap-settings.component.ts
@@ -19,6 +19,7 @@ export class BodymapSettingsComponent implements OnInit, OnDestroy {
     @Input() modalApply: Observable<any>;
     @Input() widget: WidgetConfig;
     @Input() areaId;
+    @Input() hDeviceId;
     selectedFields = [];
     private defaultConfig = {
         timeAxisRange: 10,

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/data-simulator-settings/data-simulator-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/data-simulator-settings/data-simulator-settings.component.ts
@@ -30,6 +30,8 @@ export class DataSimulatorSettingsComponent implements OnInit {
 
   @Input() settingsForm: NgForm;
 
+  @Input() hDeviceId;
+
   projectPackets: HPacket[] = [];
   groupedPacketOptions: SelectOptionGroup[] = [];
 

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/defibrillator-settings/defibrillator-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/defibrillator-settings/defibrillator-settings.component.ts
@@ -20,6 +20,7 @@ export class DefibrillatorSettingsComponent implements OnInit, OnDestroy {
     @Input() modalApply: Observable<any>;
     @Input() widget;
     @Input() areaId;
+    @Input() hDeviceId;
     @Input() selectedPacket: HPacket = null;
 
     projectPackets: Array<HPacket> = [];
@@ -52,7 +53,7 @@ export class DefibrillatorSettingsComponent implements OnInit, OnDestroy {
         unit: null,
       };
     }
-    
+
     createDefaultDefibrillatorSettings(): DefibrillatorSettings.DefibrillatorSettings {
       return {
         standard: {

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/ecg-settings/ecg-settings.component.html
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/ecg-settings/ecg-settings.component.html
@@ -15,6 +15,7 @@
       <hyperiot-packet-select
         [widget]="widget"
         [areaId]="areaId"
+        [hDeviceId]="hDeviceId"
         [multiPacketSelect]="true"
         [selectedFields]="selectedFields"
         (selectedFieldsChange)="onSelectedFieldsChange($event)"

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/ecg-settings/ecg-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/ecg-settings/ecg-settings.component.ts
@@ -19,6 +19,7 @@ export class EcgSettingsComponent implements OnInit, OnDestroy {
     @Input() modalApply: Observable<any>;
     @Input() widget;
     @Input() areaId;
+    @Input() hDeviceId;
     selectedFields = [];
     private defaultConfig = {
       bgColor: 'bright',
@@ -46,7 +47,7 @@ export class EcgSettingsComponent implements OnInit, OnDestroy {
     };
     dataFrequency = 0.2;
     dataRange = 30;
-    
+
     bgColorOptions: SelectOption[] = [
       {
         value: 'bright',

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/gauge-settings/gauge-settings.component.html
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/gauge-settings/gauge-settings.component.html
@@ -3,6 +3,7 @@
     [multiPacketSelect]="false"
     [selectedFields]="selectedFields"
     [areaId]="areaId"
+    [hDeviceId]="hDeviceId"
     (selectedFieldsChange)="onSelectedFieldsChange($event)"></hyperiot-packet-select>
 <hr>
 <div class="text-color">

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/gauge-settings/gauge-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/gauge-settings/gauge-settings.component.ts
@@ -17,7 +17,7 @@ export class GaugeSettingsComponent implements OnInit, OnDestroy {
   @Input() modalApply: Observable<any>;
   @Input() widget;
   @Input() areaId;
-
+  @Input() hDeviceId;
   maxValue: number;
   selectedFields = [];
   private defaultConfig = {

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/production-target-settings/production-target-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/production-target-settings/production-target-settings.component.ts
@@ -17,6 +17,7 @@ export class ProductionTargetSettingsComponent implements OnInit {
   @Input() areaId;
   @Input() modalApply: Observable<any>;
   @Input() settingsForm: NgForm;
+  @Input() hDeviceId;
 
   private logger: Logger;
 
@@ -26,7 +27,7 @@ export class ProductionTargetSettingsComponent implements OnInit {
   contentLoaded: boolean = false;
 
   /**
-   * Radio button options 
+   * Radio button options
    */
   isTargetManuallySetOptions = [
     { value: 'true', label: 'Set Manually', checked: true },
@@ -78,7 +79,7 @@ export class ProductionTargetSettingsComponent implements OnInit {
 
   /**
    * Saves target manually setted value
-   * @param inputValue 
+   * @param inputValue
    */
   updateTargetValue(inputValue: number) {
     this.targetValue = inputValue;
@@ -86,7 +87,7 @@ export class ProductionTargetSettingsComponent implements OnInit {
 
   /**
    * Called when radio button value is changed
-   * @param option 
+   * @param option
    */
   onTargetOptionChange(option: string): void {
     this.isTargetManuallySetOptions.forEach(target => {
@@ -182,10 +183,10 @@ export class ProductionTargetSettingsComponent implements OnInit {
 
   /**
    * Process configured widget's data
-   * @param packet 
-   * @param key 
-   * @param totalFields 
-   * @param processedFields 
+   * @param packet
+   * @param key
+   * @param totalFields
+   * @param processedFields
    */
   processPacketAndConfiguration(packet: HPacket, key: string, totalFields: number, processedFields: number) {
     this.selectedPackets[key] = packet;

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/sensor-value-settings/sensor-value-settings.component.html
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/sensor-value-settings/sensor-value-settings.component.html
@@ -3,6 +3,7 @@
     [multiPacketSelect]="false"
     [selectedFields]="selectedFields"
     [areaId]="areaId"
+    [hDeviceId]="hDeviceId"
     (selectedFieldsChange)="onSelectedFieldsChange($event)"></hyperiot-packet-select>
 <hr>
 <div class="sensor-value-text-color">

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/sensor-value-settings/sensor-value-settings.component.ts
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/sensor-value-settings/sensor-value-settings.component.ts
@@ -5,6 +5,7 @@ import { SelectOption } from 'components';
 import { Observable } from 'rxjs';
 
 import { PacketSelectComponent } from '../packet-select/packet-select.component';
+import {ActivatedRoute} from "@angular/router";
 
 @Component({
   selector: 'hyperiot-sensor-value-settings',
@@ -17,6 +18,7 @@ export class SensorValueSettingsComponent implements OnInit, OnDestroy {
   @Input() modalApply: Observable<any>;
   @Input() widget;
   @Input() areaId;
+  @Input() hDeviceId;
   selectedFields = [];
   private defaultConfig = {
     textColor: '#275691',
@@ -34,7 +36,7 @@ export class SensorValueSettingsComponent implements OnInit, OnDestroy {
     }
   ];
 
-  constructor(public settingsForm: NgForm) { }
+  constructor(public settingsForm: NgForm, private activatedRoute: ActivatedRoute) { }
 
   ngOnInit() {
     if (this.widget.config == null) {

--- a/projects/widgets/src/lib/dashboard/widget-settings-dialog/widget-settings-dialog.component.html
+++ b/projects/widgets/src/lib/dashboard/widget-settings-dialog/widget-settings-dialog.component.html
@@ -43,7 +43,7 @@
 
                 <div class="custom-settings" [ngSwitch]="widget.type">
                     <div *ngSwitchCase="'sensor-value'">
-                        <hyperiot-sensor-value-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-sensor-value-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                             [settingsForm]="settingsForm">
                         </hyperiot-sensor-value-settings>
                     </div>
@@ -53,7 +53,7 @@
                         </hyperiot-time-chart-settings>
                     </div>
                     <div *ngSwitchCase="'production-target-widget'">
-                        <hyperiot-production-target-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-production-target-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                             [settingsForm]="settingsForm">
                         </hyperiot-production-target-settings>
                     </div>
@@ -63,7 +63,7 @@
                         </hyperiot-time-chart-settings>
                     </div>
                     <div *ngSwitchCase="'gauge'">
-                        <hyperiot-gauge-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-gauge-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                             [settingsForm]="settingsForm">
                         </hyperiot-gauge-settings>
                     </div>
@@ -73,26 +73,26 @@
                         </hyperiot-time-chart-settings>
                     </div>
                     <div *ngSwitchCase="'time-chart'">
-                        <hyperiot-time-chart-settings [checkbox]="true" [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-time-chart-settings [checkbox]="true" [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                             [settingsForm]="settingsForm">
                         </hyperiot-time-chart-settings>
                     </div>
                     <div *ngSwitchCase="'bodymap'">
-                      <hyperiot-bodymap-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                      <hyperiot-bodymap-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                                                [settingsForm]="settingsForm"></hyperiot-bodymap-settings>
                     </div>
                     <div *ngSwitchCase="'ecg'">
-                      <hyperiot-ecg-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                      <hyperiot-ecg-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                                                     [settingsForm]="settingsForm">
                       </hyperiot-ecg-settings>
                     </div>
                     <div *ngSwitchCase="'defibrillator'">
-                        <hyperiot-defibrillator-settings [widget]="widget" [areaId]="areaId" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-defibrillator-settings [widget]="widget" [areaId]="areaId" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                                                       [settingsForm]="settingsForm">
                         </hyperiot-defibrillator-settings>
                       </div>
                     <div *ngSwitchCase="'algorithm-offline-table'">
-                        <hyperiot-algorithm-settings [widget]="widget" [modalApply]="modalApply.asObservable()"
+                        <hyperiot-algorithm-settings [widget]="widget" [hDeviceId]="hDeviceId" [modalApply]="modalApply.asObservable()"
                             [settingsForm]="settingsForm">
                         </hyperiot-algorithm-settings>
                     </div>


### PR DESCRIPTION
Into a widget setting form filtered correct device for: sensor-value, offline-table, realtime-table, gauge, histogram, time-chart, multi-status and dynamic-label-value.