### PR TITLE
Linechart fullscreen convertion fix

### DIFF
--- a/projects/core/src/lib/hyperiot-base/realtime-data-service/realtime-data.service.ts
+++ b/projects/core/src/lib/hyperiot-base/realtime-data-service/realtime-data.service.ts
@@ -122,6 +122,18 @@ export class RealtimeDataService extends BaseDataService implements IDataService
     return dataChannel;
   }
 
+  copyDataChannel(widgetId: number, originalChannelId: number) {
+    const originalChannel = this.dataChannels[originalChannelId];
+    if (!originalChannel) {
+      throw 'channel with id ' + originalChannelId + ' not found';
+    }
+    const dataChannel = super.copyDataChannel(widgetId, originalChannelId);
+    dataChannel.controller = new RealtimeDataChannelController();
+    (dataChannel.controller.dataStreamOutput$ as Observable<PacketDataChunk>).subscribe(dataChannel.subject);
+
+    return dataChannel;
+  }
+
   private onWsOpen() {
     this.isConnected = true;
   }

--- a/projects/widgets/src/lib/base/base-widget/base-widget.component.ts
+++ b/projects/widgets/src/lib/base/base-widget/base-widget.component.ts
@@ -119,7 +119,7 @@ export abstract class BaseWidgetComponent implements OnChanges, OnInit, OnDestro
     return +Object.keys(packetFields).find(key => packetFields[key] === fieldName);
   }
 
-  computePacketData(packetData: PacketData[]) {
+  computePacketData(packetData: PacketData[], convertOldValues = true) {
     if (!this.widget.config.fieldUnitConversions) {
       return;
     }
@@ -135,34 +135,37 @@ export abstract class BaseWidgetComponent implements OnChanges, OnInit, OnDestro
           // TODO all configs should contain information about field type
           fieldType = this.widget.config.fieldTypes[fieldId];
         } catch (error) { }
-        switch(fieldType) {
+        switch (fieldType) {
           case 'DEFAULT':
           case 'INTEGER':
           case 'DOUBLE':
           case 'FLOAT': {
             // TODO: inserire qui la conversione dei valori con expression
             const unitConversion = this.widget.config.fieldUnitConversions[fieldId];
-            // temp fix. packet values shouldn't be forcibly converted
+            // temp fix. packet values shouldn't be forcibly converted            
+
             if (!isNaN(parseFloat(pd[packetKey]))) {
               pd[packetKey] = parseFloat(pd[packetKey]);
             }
             if (unitConversion && typeof pd[packetKey] === 'number') {
               // applying unit conversion
               if (unitConversion.convertFrom !== unitConversion.convertTo) {
-                pd[packetKey] = convert(pd[packetKey])
-                  .from(unitConversion.convertFrom)
-                  .to(unitConversion.convertTo);
+                if (convertOldValues) {
+                  pd[packetKey] = convert(pd[packetKey])
+                    .from(unitConversion.convertFrom)
+                    .to(unitConversion.convertTo);
+                }
               }
               pd[packetKey] = +pd[packetKey];
               // applying approximation
               try {
                 pd[packetKey] = pd[packetKey].toFixed(unitConversion.decimals);
               }
-              catch(error) {
+              catch (error) {
                 this.logger.error(error);
               }
               try {
-                if(this.widget.config.fieldCustomConversions
+                if (this.widget.config.fieldCustomConversions
                   && this.widget.config.fieldCustomConversions[fieldId]
                   && this.widget.config.fieldCustomConversions[fieldId].expression
                   && this.widget.config.fieldCustomConversions[fieldId].expression.trim() !== '') {

--- a/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
+++ b/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
@@ -216,7 +216,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
     this.logger.debug("subscribeAndInit");
     this.subscribeDataChannel();
     if (this.serviceType === ServiceType.ONLINE) {
-      this.computePacketData(this.initData);
+      this.computePacketData(this.initData, this.isToolbarVisible);
     }
 
     const resizeObserver = new ResizeObserver((entries) => {
@@ -241,15 +241,18 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
       this.widget.config.packetFields,
       true
     );
+
     this.channelId = +this.widget.id;
-    if (!this.isToolbarVisible && this.serviceType === ServiceType.OFFLINE) {
+
+    if (this.isToolbarVisible) {
+      this.dataChannel = this.dataService.addDataChannel(this.channelId, [dataPacketFilter]);
+    } else {
       // setting negative id to fullscreen offline widget to prevent updating original widget
       // TODO channelId should be a proper string
       this.channelId = -this.channelId;
       this.dataChannel = this.dataService.copyDataChannel(this.channelId, -this.channelId);
-    } else {
-      this.dataChannel = this.dataService.addDataChannel(this.channelId, [ dataPacketFilter ]);
     }
+
     this.dataSubscription = this.dataChannel.subject
       .pipe(
         map((dataChunk) => dataChunk.data),
@@ -263,9 +266,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
       this.offControllerSubscription =
         this.dataChannel.controller.$totalCount.subscribe((res) => {
           this.totalLength = res;
-          if (!this.isToolbarVisible) { // if fullscreen
-            this.computePacketData(this.initData);
-          } else {
+          if (this.isToolbarVisible) {
             this.allData = [];
             this.graph.data.forEach((tsd) => {
               (tsd.x = []), (tsd.y = []);
@@ -277,19 +278,23 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
                 this.dataRequest();
               }
             }
+          } else { // if fullscreen            
+            this.computePacketData(this.initData);
           }
         });
     }
   }
 
-  async computePacketData(packetData: PacketData[]) {
+  async computePacketData(packetData: PacketData[], convertOldValues = true) {
     this.logger.debug("computePacketData", packetData);
-    super.computePacketData(packetData);
 
     if (packetData.length === 0) {
       return;
     }
-    this.allData = this.allData.concat(packetData);
+
+    this.allData = this.allData.concat([...packetData]);
+
+    super.computePacketData(packetData, convertOldValues);
 
     packetData.forEach((datum) => {
       if (
@@ -300,6 +305,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
       }
       this.convertAndBufferData(datum);
     });
+
     await this.renderBufferedData();
     this.loadingOfflineData = false;
     if (this.serviceType === ServiceType.OFFLINE) {
@@ -625,7 +631,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
         this.pause();
         break;
       case "toolbar:fullscreen":
-        widgetAction.value = this.allData;
+        widgetAction.value = [...this.allData];
         break;
     }
 

--- a/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
+++ b/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
@@ -180,6 +180,8 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
   configure() {
     this.graph.layout = {};
     this.graph.data = [];
+    this.allData = [];
+    
     super.removeSubscriptionsAndDataChannels();
     if (!this.serviceType) {
       this.logger.error("TYPE SERVICE UNDEFINED");

--- a/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
+++ b/projects/widgets/src/lib/widget/line-chart/line-chart.component.ts
@@ -181,7 +181,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
     this.graph.layout = {};
     this.graph.data = [];
     this.allData = [];
-    
+
     super.removeSubscriptionsAndDataChannels();
     if (!this.serviceType) {
       this.logger.error("TYPE SERVICE UNDEFINED");
@@ -281,7 +281,7 @@ export class LineChartComponent extends BaseChartComponent implements OnInit {
               }
             }
           } else { // if fullscreen            
-            this.computePacketData(this.initData);
+            this.computePacketData(this.initData, this.isToolbarVisible);
           }
         });
     }


### PR DESCRIPTION
Added a new flag "convertOldValues" to avoid a double convertion on fullscreen
Reset allData on widget config update