### PR TITLE
fix: remove selectedHProjectId from store and stabilize dashboard project selection

### DIFF
--- a/projects/core/src/lib/store/data-export-notification/data-export-notification.reducer.ts
+++ b/projects/core/src/lib/store/data-export-notification/data-export-notification.reducer.ts
@@ -2,7 +2,6 @@ import { createReducer, on } from "@ngrx/store";
 import { createEntityAdapter, EntityAdapter, EntityState } from "@ngrx/entity";
 import { DataExportNotificationActions } from "./data-export-notification.actions";
 import { HPacket } from "../../hyperiot-client/hyt-api/api-module/model/hPacket";
-import { HProject } from "../../hyperiot-client/hyt-api/api-module/model/hProject";
 
 export namespace DataExportNotificationStore {
 
@@ -12,7 +11,7 @@ export namespace DataExportNotificationStore {
     exportParams: {
       exportId: string;
       exportName: string,
-      hProject: HProject;
+      hProjectId: number;
       hPacket: HPacket;
       hPacketFormat: HPacket.FormatEnum,
       startTime: Date,

--- a/projects/core/src/lib/store/hProjects/hProjects.actions.ts
+++ b/projects/core/src/lib/store/hProjects/hProjects.actions.ts
@@ -21,7 +21,6 @@ export namespace HProjectActions {
     export const deleteHProject = createAction('[HProject/API] Delete HProject', props<{ id: number }>());
     export const deleteHProjects = createAction('[HProject/API] Delete HProjects', props<{ ids: number[] }>());
     export const deleteHProjectsByPredicate = createAction('[HProject/API] Delete HProjects By Predicate', props<{ predicate: Predicate<HProject> }>());
-    export const setSelectedHProjectId = createAction('[HProject/API] Set SelectedHProjectId', props<{ id: number }>());
     export const clearHProjects = createAction('[HProject/API] Clear HProjects');
 
 }

--- a/projects/core/src/lib/store/hProjects/hProjects.reducer.ts
+++ b/projects/core/src/lib/store/hProjects/hProjects.reducer.ts
@@ -8,16 +8,11 @@ export namespace HProjectStore {
   export const key = 'hProjects';
 
   export interface State extends EntityState<HProject> {
-    // additional entities state properties
-    selectedHProjectId: number | null;
   }
 
   export const adapter: EntityAdapter<HProject> = createEntityAdapter<HProject>();
 
-  export const initialState: State = adapter.getInitialState({
-    // additional entity state properties
-    selectedHProjectId: null,
-  });
+  export const initialState: State = adapter.getInitialState({});
 
   export const reducer = createReducer(
     initialState,
@@ -25,10 +20,7 @@ export namespace HProjectStore {
       return { ...state };
     }),
     on(HProjectActions.loadHProjectsSuccess, (state, { hProjects }) => {
-      return adapter.setAll(hProjects, {
-        ...state,
-        // selectedHProjectId: null
-      });
+      return adapter.setAll(hProjects, state);
     }),
     on(HProjectActions.loadHProjectsFailure, (state, { error }) => {
       return { ...state };
@@ -72,18 +64,10 @@ export namespace HProjectStore {
     on(HProjectActions.setHProjects, (state, { hProjects }) => {
       return adapter.setMany(hProjects, state);
     }),
-    on(HProjectActions.setSelectedHProjectId, (state, { id }) => {
-      return {
-        ...state,
-        selectedHProjectId: id
-      };
-    }),
     on(HProjectActions.clearHProjects, state => {
-      return adapter.removeAll({ ...state, selectedHProjectId: null });
+      return adapter.removeAll(state);
     })
   );
-
-  export const getSelectedHProjectId = (state: State) => state.selectedHProjectId;
 
   // get the selectors
   const {

--- a/projects/core/src/lib/store/hProjects/hProjects.selectors.ts
+++ b/projects/core/src/lib/store/hProjects/hProjects.selectors.ts
@@ -21,17 +21,6 @@ export namespace HProjectSelectors {
     selectHProjectState,
     HProjectStore.selectHProjectTotal
   );
-  export const selectCurrentHProjectId = createSelector(
-    selectHProjectState,
-    HProjectStore.getSelectedHProjectId
-  );
-  
-  export const selectCurrentHProject = createSelector(
-    selectHProjectEntities,
-    selectCurrentHProjectId,
-    (alarmEnetities, userId) => userId && alarmEnetities[userId]
-  );
-  
   export const selectHProjectById = (props: {id: number}) => createSelector(
     selectHProjectEntities,
     (hProjectEnetities) => props.id && hProjectEnetities[props.id]

--- a/projects/widgets/src/lib/dashboard/dashboard.component.ts
+++ b/projects/widgets/src/lib/dashboard/dashboard.component.ts
@@ -17,15 +17,13 @@ import {
   Dashboard, HDevice,
   HDevicesService,
   HProject,
-  HProjectActions,
-  HProjectSelectors,
   Logger,
   LoggerService,
   OfflineDataService,
   UserSiteSettingActions,
   UserSiteSettingSelectors
 } from 'core';
-import { debounceTime, delay, firstValueFrom, PartialObserver, Subject, Subscription, takeUntil, tap } from 'rxjs';
+import { debounceTime, delay, PartialObserver, Subject, Subscription, takeUntil, tap } from 'rxjs';
 import { AddWidgetDialogComponent } from './add-widget-dialog/add-widget-dialog.component';
 import { DashboardConfigService } from './dashboard-config.service';
 import { DashboardViewComponent } from './dashboard-view/dashboard-view.component';
@@ -198,11 +196,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.logger.registerClass(DashboardComponent.name);
   }
 
-  async ngOnInit() {
+  ngOnInit() {
     this.showAreas = this.activatedRoute.snapshot.routeConfig.path.startsWith('areas/');
     this.showHDevice = this.activatedRoute.snapshot.routeConfig.path.startsWith('hdevice/');
 
-    await this.initIdProjectSelected();
+    this.idProjectSelected = +this.activatedRoute.snapshot.params.projectId;
+
+    // For project dashboard, try to restore last selected project id from localStorage if idProjectSelected is null
+    if (!this.idProjectSelected && !this.showAreas && !this.showHDevice) {
+      this.idProjectSelected = +localStorage.getItem('last-dashboard-project') || null;
+    }
 
     this.offlineDataService.countEventSubject.subscribe(res => {
       this.offlineWidgetStatus = res;
@@ -284,25 +287,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.ngUnsubscribe.next();
     }
 
-    this.store.dispatch(HProjectActions.setSelectedHProjectId({ id: null }));
-  }
-
-  private async initIdProjectSelected() {
-    const projectId = +this.activatedRoute.snapshot.params.projectId;
-    if (this.showAreas || this.showHDevice) {
-      this.idProjectSelected = projectId;
-    } else {
-      this.idProjectSelected = projectId || await firstValueFrom(this.store.select(HProjectSelectors.selectCurrentHProjectId));
-
-      if (!this.idProjectSelected) {
-        this.hProjectListOptions = await firstValueFrom(this.dashboardConfigService.getProjectsList());
-        if (this.hProjectListOptions.length > 0) {
-          this.idProjectSelected = this.hProjectListOptions[0].id;
-        }
-      }
-    }
-
-    this.store.dispatch(HProjectActions.setSelectedHProjectId({ id: this.idProjectSelected }));
   }
 
   private loadDashboardByDatasource(defaultDatasource: Dashboard.DashboardTypeEnum) {
@@ -348,8 +332,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.idProjectSelected = event.value;
     this.recordStateInLoading = true;
     clearInterval(this.updateRecordingInterval);
-
-    this.store.dispatch(HProjectActions.setSelectedHProjectId({ id: this.idProjectSelected }));
 
     if (this.signalIsOn) {
       this.updateTopologyStatus();
@@ -497,6 +479,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
             });
 
             if (this.hProjectListOptions.length > 0) {
+              if (!this.idProjectSelected || !this.hProjectList.some(hProject => hProject.id === this.idProjectSelected)) {
+                // Fallback to first available project id if idProjectSelected is null or no project matches that id
+                this.idProjectSelected = this.hProjectListOptions[0].id;
+              }
               this.store.select(UserSiteSettingSelectors.selectDefaultProjectsDashboardDataSource)
                 .subscribe((defaultDatasource) => {
                   this.loadDashboardByDatasource(defaultDatasource);
@@ -580,6 +566,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
         .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe(responseHandler, errorHandler);
     } else {
+      // Update last visited project id in localStorage
+      localStorage.setItem('last-dashboard-project', String(this.idProjectSelected));
+      // Sync project ID in URL
+      this.router.navigate(['dashboards', this.idProjectSelected], { replaceUrl: true });
       // load project realtime Dashboard
       this.dashboardConfigService.getRealtimeDashboardFromProject(this.idProjectSelected)
         .pipe(takeUntil(this.ngUnsubscribe))

--- a/projects/widgets/src/lib/dashboard/timeline/data-export/data-export.component.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/data-export/data-export.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, ValidationErrors, Validators } from '@angular/forms';
 import { DialogRef, DIALOG_DATA, SelectOptionGroup, HytSelectComponent } from 'components';
-import { DataExport } from '../models/data-export,model';
+import { DataExport } from '../models/data-export.model';
 import { Store } from '@ngrx/store';
 import {
   DataExportNotificationActions,

--- a/projects/widgets/src/lib/dashboard/timeline/data-export/data-export.component.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/data-export/data-export.component.ts
@@ -9,8 +9,6 @@ import {
   HDeviceSelectors,
   HPacket,
   HPacketSelectors,
-  HProject,
-  HProjectSelectors,
   HProjectService,
   Logger,
   LoggerService,
@@ -106,7 +104,7 @@ export class DataExportComponent implements OnInit, AfterViewInit, OnDestroy {
   hPacketList: HPacket[] = [];
   hPacketListSelected: HPacket[] = [];
 
-  private hProject: HProject;
+  private currentProjectId: number;
 
   private logger: Logger;
 
@@ -151,18 +149,17 @@ export class DataExportComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       });
 
-    this.store.select(HProjectSelectors.selectCurrentHProject)
-      .pipe(
-        tap((hProject) => this.hProject = hProject),
-        switchMap((hProject) => combineLatest({
-          hDeviceList: this.store.select(HDeviceSelectors.selectAllHDevices)
-            .pipe(
-              map((res) => res.filter(({ project }) => project.id === hProject.id)),
-            ),
-          hPacketList: this.store.select(HPacketSelectors.selectAllHPackets)
-        })),
-        take(1)
-      ).subscribe({
+    this.currentProjectId = 'exportParams' in this.data
+      ? this.data.exportParams.hProjectId
+      : this.data.projectId;
+
+    combineLatest({
+      hDeviceList: this.store.select(HDeviceSelectors.selectAllHDevices)
+        .pipe(
+          map((res) => res.filter(({ project }) => project.id === this.currentProjectId)),
+        ),
+      hPacketList: this.store.select(HPacketSelectors.selectAllHPackets)
+    }).pipe(take(1)).subscribe({
         next: ({ hDeviceList, hPacketList }) => {
           this.hPacketList = hPacketList;
 
@@ -293,8 +290,7 @@ export class DataExportComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.exportErrorList = [];
 
-    const hProject = this.hProject;
-    const hProjectId = hProject.id;
+    const hProjectId = this.currentProjectId;
     const exportName: string = this.exportName.value;
 
     const startTime = this.startTime.value;
@@ -377,7 +373,7 @@ export class DataExportComponent implements OnInit, AfterViewInit, OnDestroy {
               const notification: DataExportNotificationStore.DataExportNotification = {
                 exportParams: {
                   exportId,
-                  hProject,
+                  hProjectId,
                   hPacket,
                   hPacketFormat,
                   exportName,

--- a/projects/widgets/src/lib/dashboard/timeline/models/data-export,model.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/models/data-export,model.ts
@@ -1,4 +1,0 @@
-export type DataExport = {
-  projectId: number;
-  timeInterval: Date[]
-}

--- a/projects/widgets/src/lib/dashboard/timeline/models/data-export,model.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/models/data-export,model.ts
@@ -1,3 +1,4 @@
 export type DataExport = {
+  projectId: number;
   timeInterval: Date[]
 }

--- a/projects/widgets/src/lib/dashboard/timeline/models/data-export.model.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/models/data-export.model.ts
@@ -1,3 +1,4 @@
 export type DataExport = {
+  projectId: number;
   timeInterval: Date[]
 }

--- a/projects/widgets/src/lib/dashboard/timeline/timeline.component.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/timeline.component.ts
@@ -291,6 +291,7 @@ export class TimelineComponent implements OnChanges {
       DataExportComponent,
       {
         data: {
+          projectId: this.projectId,
           timeInterval: this.timeSelection
         },
         height: '600px',

--- a/projects/widgets/src/lib/dashboard/timeline/timeline.component.ts
+++ b/projects/widgets/src/lib/dashboard/timeline/timeline.component.ts
@@ -5,7 +5,7 @@ import * as moment_ from 'moment';
 import 'moment-precise-range-plugin';
 import { TimeAxisComponent } from './time-axis/time-axis.component';
 import { DashboardEventService } from '../services/dashboard-event.service';
-import { DataExport } from './models/data-export,model';
+import { DataExport } from './models/data-export.model';
 import { DataExportComponent } from './data-export/data-export.component';
 import { MatSelectChange } from '@angular/material/select';
 import { DefaultTimelineCustomRange, DefaultTimelineRange, DefaultTimelineRangeType, DefaultTimelineRangeTypeUtilsMap } from '../model/dashboardTimelineDefaultRange';

--- a/src/app/configuration-modules/hyt-routing.module.ts
+++ b/src/app/configuration-modules/hyt-routing.module.ts
@@ -253,6 +253,14 @@ const hyperiotRoutes: Routes = [
     }
   },
   {
+    path: 'dashboards/:projectId',
+    component: DashComponent,
+    canActivate: [LoggedInGuard],
+    data: {
+      showToolBar: true,
+    },
+  },
+  {
     path: 'areas',
     component: AreasViewComponent,
     canActivate: [LoggedInGuard],

--- a/src/app/pages/projects/project-detail/project-detail.component.ts
+++ b/src/app/pages/projects/project-detail/project-detail.component.ts
@@ -622,7 +622,7 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
 
   goToDashboard() {
     this.logger.debug('goToDashboard');
-    this.router.navigate(['/dashboards'], { queryParams: { projectId: this.projectId } });
+    this.router.navigate(['/dashboards', this.projectId]);
   }
 
   /**


### PR DESCRIPTION
- project detail: fix go-to-dashboard
- Project Dashboard: fix project id resolution using URL params with localStorage and first available project as fallbacks
- DataExport: fix retry loading devices/packets from wrong project by passing projectId via dialog data instead of NgRx store
- Store: remove selectedHProjectId from HProject store
- fix: correct data-export model filename typo